### PR TITLE
Add format options for field listings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,8 @@ Project Overview is a Drupal module that provides a centralized dashboard for vi
 ## Features
 
 - **Project Overview Dashboard:** View a summary page with project information.
-- **Entities and Fields:** List all content entity types and their fields.
+- **Entities and Fields:** List all content entity types and their fields. Add
+  `?format=json` or `?format=markdown` to the URL for alternative outputs.
 - **Services Report:** View all custom services registered in the service container.
 - **Routes List:** Display all routes defined by custom modules.
 - **Providers List:** See all entity types grouped by their provider.


### PR DESCRIPTION
## Summary
- support HTML, JSON or Markdown formats in EntityListingController
- document format query options in README

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a365d78c48329bda63f0eeb6211a4