### PR TITLE
Use dev-only Drupal core dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Project Overview module for Drupal",
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
-    "require": {
+    "require": {},
+    "require-dev": {
         "drupal/core": "^10 || ^11"
     },
     "autoload": {

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ Drupal core version ^10 or ^11
 Controllers are located in src/Controller.
 Custom theme hook is defined in project_overview.module.
 Menu and routing configuration can be found in the .yml files.
+Run `composer install` to pull in development dependencies like Drupal core.
 
 ## License
 GPL-2.0-or-later


### PR DESCRIPTION
## Summary
- move Drupal core to `require-dev`
- document running composer install for dev deps

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a430edfe88329a8fecbb0d6cc18d1